### PR TITLE
fix & optimize copy paste

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/dsheet",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/dsheet",
-      "version": "4.1.5",
+      "version": "4.1.6",
       "dependencies": {
         "@fileverse-dev/dsheets-templates": "0.0.34",
         "@fileverse-dev/formulajs": "4.4.55",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/dsheet",
   "private": false,
   "description": "DSheet",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/src/sheet-engine/core/locale/en.ts
+++ b/src/sheet-engine/core/locale/en.ts
@@ -11286,7 +11286,9 @@ export default {
     MicrosoftYaHei: 'YaHei',
   },
   fontarray: ['Arial', 'Times New Roman', 'Tahoma', 'Verdana'],
-  fontjson: { 'times new roman': 0, arial: 1, tahoma: 2, verdana: 3 },
+  // fontjson MUST match fontarray index order (used to map a pasted font-family
+  // name back to an ff index). Arial=0 here to match fontarray[0]='Arial'.
+  fontjson: { arial: 0, 'times new roman': 1, tahoma: 2, verdana: 3 },
   border: {
     borderTop: 'Top border',
     borderBottom: 'Bottom border',

--- a/src/sheet-engine/core/modules/copy-range-bounds.ts
+++ b/src/sheet-engine/core/modules/copy-range-bounds.ts
@@ -1,0 +1,49 @@
+/**
+ * Trim two selection index arrays down to the bounding box of "meaningful" cells.
+ *
+ * `rowIndexArr`/`colIndexArr` are sheet row/column indices in selection order.
+ * `isMeaningful(r, c)` decides whether a cell contributes content (data, border, or
+ * conditional format). Returns the sub-arrays spanning the first→last meaningful
+ * position in each axis. If no cell is meaningful (e.g. select-all of an empty sheet),
+ * the selection collapses to a single top-left cell so we never serialise a whole grid
+ * of blank cells.
+ *
+ * This is what stops a select-all of a mostly-empty (or fully-empty) sheet from
+ * serialising thousands of blank `<td>`s. Dropped rows/cols hold no data and no CSS, so
+ * the trim is lossless — it matches Google Sheets' used-range clamp.
+ */
+export function clampIndicesToUsedBounds(
+  rowIndexArr: number[],
+  colIndexArr: number[],
+  isMeaningful: (r: number, c: number) => boolean,
+): { rows: number[]; cols: number[] } {
+  let minRowPos = Infinity;
+  let maxRowPos = -Infinity;
+  let minColPos = Infinity;
+  let maxColPos = -Infinity;
+
+  for (let i = 0; i < rowIndexArr.length; i += 1) {
+    for (let j = 0; j < colIndexArr.length; j += 1) {
+      if (isMeaningful(rowIndexArr[i], colIndexArr[j])) {
+        if (i < minRowPos) minRowPos = i;
+        if (i > maxRowPos) maxRowPos = i;
+        if (j < minColPos) minColPos = j;
+        if (j > maxColPos) maxColPos = j;
+      }
+    }
+  }
+
+  if (maxRowPos === -Infinity) {
+    // No meaningful cell in the selection — collapse to a single top-left cell so a
+    // select-all of an empty sheet does not serialise the entire blank grid.
+    return {
+      rows: rowIndexArr.length ? [rowIndexArr[0]] : [],
+      cols: colIndexArr.length ? [colIndexArr[0]] : [],
+    };
+  }
+
+  return {
+    rows: rowIndexArr.slice(minRowPos, maxRowPos + 1),
+    cols: colIndexArr.slice(minColPos, maxColPos + 1),
+  };
+}

--- a/src/sheet-engine/core/modules/selection.ts
+++ b/src/sheet-engine/core/modules/selection.ts
@@ -23,7 +23,8 @@ import { delFunctionGroup } from './formula';
 import clipboard from './clipboard';
 import { clearImageClipboard } from './image-clipboard';
 import { getBorderInfoCompute } from './border';
-import { getComputeMap } from './ConditionFormat';
+import { checkCF, getComputeMap } from './ConditionFormat';
+import { clampIndicesToUsedBounds } from './copy-range-bounds';
 import {
   escapeHTMLTag,
   getSheetIndex,
@@ -1941,8 +1942,8 @@ export function rangeValueToHtml(
   if (idx == null) return '';
   const sheet = ctx.luckysheetfile[idx];
 
-  const rowIndexArr: number[] = [];
-  const colIndexArr: number[] = [];
+  let rowIndexArr: number[] = [];
+  let colIndexArr: number[] = [];
 
   for (let s = 0; s < (ranges?.length ?? 0); s += 1) {
     const range = ranges![s];
@@ -1966,7 +1967,7 @@ export function rangeValueToHtml(
     }
   }
 
-  let borderInfoCompute;
+  let borderInfoCompute: Record<string, any> | undefined;
   if (sheet.config?.borderInfo && sheet.config.borderInfo.length > 0) {
     // 边框
     borderInfoCompute = getBorderInfoCompute(ctx, sheetId);
@@ -1975,6 +1976,19 @@ export function rangeValueToHtml(
   let cpdata = '';
   const d = sheet.data;
   if (!d) return null;
+
+  // Clamp the serialised range to the bounding box of cells that actually carry
+  // content (data, border, or conditional format). Stops a select-all of a mostly-
+  // empty sheet from emitting thousands of blank <td>s (the whole-sheet copy blowup).
+  // Trimmed cells hold no data and no CSS, so the copy stays lossless.
+  ({ rows: rowIndexArr, cols: colIndexArr } = clampIndicesToUsedBounds(
+    rowIndexArr,
+    colIndexArr,
+    (r, c) =>
+      d[r]?.[c] != null ||
+      (borderInfoCompute != null && borderInfoCompute[`${r}_${c}`] != null) ||
+      checkCF(r, c, cf_compute) != null,
+  ));
 
   let colgroup = '';
 

--- a/src/sheet-engine/core/modules/selection.ts
+++ b/src/sheet-engine/core/modules/selection.ts
@@ -2014,12 +2014,17 @@ export function rangeValueToHtml(
         let span = '';
 
         if (r === rowIndexArr[0]) {
+          // When a column carries no explicit width, the grid renders it at the
+          // sheet's default width — so the clipboard must serialize THAT default,
+          // not a hardcoded value. Emitting a wrong fallback (e.g. 72) silently
+          // resizes columns on the next paste when the real default differs.
+          const fallbackColW = sheet.defaultColWidth ?? ctx.defaultcollen;
           if (
             _.isNil(sheet.config) ||
             _.isNil(sheet.config.columnlen) ||
             _.isNil(sheet.config.columnlen[c.toString()])
           ) {
-            colgroup += '<colgroup width="72px"></colgroup>';
+            colgroup += `<colgroup width="${fallbackColW}px"></colgroup>`;
           } else {
             colgroup += `<colgroup width="${
               sheet.config.columnlen[c.toString()]
@@ -2028,12 +2033,15 @@ export function rangeValueToHtml(
         }
 
         if (c === colIndexArr[0]) {
+          // Same as column width: fall back to the sheet's default row height,
+          // not a hardcoded value, so default-height rows round-trip losslessly.
+          const fallbackRowH = sheet.defaultRowHeight ?? ctx.defaultrowlen;
           if (
             _.isNil(sheet.config) ||
             _.isNil(sheet.config.rowlen) ||
             _.isNil(sheet.config.rowlen[r.toString()])
           ) {
-            style += 'height:19px;';
+            style += `height:${fallbackRowH}px;`;
           } else {
             style += `height:${sheet.config.rowlen[r.toString()]}px;`;
           }
@@ -2355,12 +2363,17 @@ export function rangeValueToHtml(
         column += '';
 
         if (r === rowIndexArr[0]) {
+          // When a column carries no explicit width, the grid renders it at the
+          // sheet's default width — so the clipboard must serialize THAT default,
+          // not a hardcoded value. Emitting a wrong fallback (e.g. 72) silently
+          // resizes columns on the next paste when the real default differs.
+          const fallbackColW = sheet.defaultColWidth ?? ctx.defaultcollen;
           if (
             _.isNil(sheet.config) ||
             _.isNil(sheet.config.columnlen) ||
             _.isNil(sheet.config.columnlen[c.toString()])
           ) {
-            colgroup += '<colgroup width="72px"></colgroup>';
+            colgroup += `<colgroup width="${fallbackColW}px"></colgroup>`;
           } else {
             colgroup += `<colgroup width="${
               sheet.config.columnlen[c.toString()]
@@ -2369,12 +2382,15 @@ export function rangeValueToHtml(
         }
 
         if (c === colIndexArr[0]) {
+          // Same as column width: fall back to the sheet's default row height,
+          // not a hardcoded value, so default-height rows round-trip losslessly.
+          const fallbackRowH = sheet.defaultRowHeight ?? ctx.defaultrowlen;
           if (
             _.isNil(sheet.config) ||
             _.isNil(sheet.config.rowlen) ||
             _.isNil(sheet.config.rowlen[r.toString()])
           ) {
-            style += 'height:19px;';
+            style += `height:${fallbackRowH}px;`;
           } else {
             style += `height:${sheet.config.rowlen[r.toString()]}px;`;
           }

--- a/src/sheet-engine/core/modules/selection.ts
+++ b/src/sheet-engine/core/modules/selection.ts
@@ -25,6 +25,7 @@ import { clearImageClipboard } from './image-clipboard';
 import { getBorderInfoCompute } from './border';
 import { checkCF, getComputeMap } from './ConditionFormat';
 import { clampIndicesToUsedBounds } from './copy-range-bounds';
+import { isClipboardMetadataRedundant } from '../utils/cell-persist-utils';
 import {
   escapeHTMLTag,
   getSheetIndex,
@@ -2292,11 +2293,12 @@ export function rangeValueToHtml(
           }
         }
 
-        const cellData = includeCellMetadata
-          ? encodeURIComponent(
-              JSON.stringify({ ...cell, _srcRow: r, _srcCol: c }),
-            )
-          : '';
+        const cellData =
+          includeCellMetadata && !isClipboardMetadataRedundant(cell)
+            ? encodeURIComponent(
+                JSON.stringify({ ...cell, _srcRow: r, _srcCol: c }),
+              )
+            : '';
         column = replaceHtml(column, { style, span, cellData });
 
         if (_.isNil(c_value)) {

--- a/src/sheet-engine/core/paste-table-helpers.ts
+++ b/src/sheet-engine/core/paste-table-helpers.ts
@@ -20,7 +20,9 @@ function parseTdBorderSide(
   td: HTMLTableCellElement,
   side: 'Top' | 'Bottom' | 'Left' | 'Right',
 ): [number, string] | null {
-  const shorthand = td.style[`border${side}` as keyof CSSStyleDeclaration] as string;
+  const shorthand = td.style[
+    `border${side}` as keyof CSSStyleDeclaration
+  ] as string;
   if (
     shorthand &&
     (shorthand.startsWith('0px') || shorthand.startsWith('0 '))
@@ -28,22 +30,37 @@ function parseTdBorderSide(
     return null;
   }
 
-  const width = td.style[`border${side}Width` as keyof CSSStyleDeclaration] as string;
+  const width = td.style[
+    `border${side}Width` as keyof CSSStyleDeclaration
+  ] as string;
   const borderStyle = td.style[
     `border${side}Style` as keyof CSSStyleDeclaration
   ] as string;
-  const color = td.style[`border${side}Color` as keyof CSSStyleDeclaration] as string;
+  const color = td.style[
+    `border${side}Color` as keyof CSSStyleDeclaration
+  ] as string;
 
-  if (!width || !borderStyle || borderStyle === 'none' || borderStyle === 'hidden') {
+  if (
+    !width ||
+    !borderStyle ||
+    borderStyle === 'none' ||
+    borderStyle === 'hidden'
+  ) {
     return null;
   }
 
   const nWidth = parseFloat(width);
-  if (Number.isNaN(nWidth) || nWidth < 1) return null;
+  // Reject only zero-width borders. A sub-1px value is still a real border — dsheet's
+  // own copy emits thin borders as `0.5pt` (external Sheets sends `1px`). Rejecting `< 1` here
+  // dropped dsheet→dsheet borders, so the light gridline showed through the inter-cell
+  // gaps as white lines. getQKBorder maps the width→thickness (0.5pt → thin) and
+  // returns type 0 for anything genuinely empty, which line 48 still filters.
+  if (Number.isNaN(nWidth) || nWidth <= 0) return null;
   if (isTransparentBorderColor(color)) return null;
 
   const qk = getQKBorder(width, borderStyle, color) as [number, string];
-  if (!qk || qk[0] === 0 || isTransparentBorderColor(String(qk[1]))) return null;
+  if (!qk || qk[0] === 0 || isTransparentBorderColor(String(qk[1])))
+    return null;
   return [qk[0], qk[1]];
 }
 
@@ -162,6 +179,11 @@ const getInlineStringSegmentsFromTd = (
     if (el.style?.cssText) {
       Array.from(el.style).forEach((prop) => {
         if (prop === 'font-size') return;
+        // Borders are cell-level (handled by applyBordersAndMerges). Never copy them
+        // onto a text run: convertCssToStyleList treats `border-bottom` as underline,
+        // so a cell's bottom border would wrongly underline all its text (external
+        // Sheets cells, which carry `border: 1px solid …`).
+        if (prop === 'border' || prop.startsWith('border-')) return;
         const val = el.style.getPropertyValue(prop);
         if (val) newCss[prop] = val;
       });
@@ -270,12 +292,7 @@ function applyBordersAndMerges(
 
       if (cellBorders.l || cellBorders.r || cellBorders.t || cellBorders.b) {
         const meaningful = filterMeaningfulBorderSides(cellBorders);
-        if (
-          meaningful.l ||
-          meaningful.r ||
-          meaningful.t ||
-          meaningful.b
-        ) {
+        if (meaningful.l || meaningful.r || meaningful.t || meaningful.b) {
           borderInfo[`${relativeRow}_${relativeCol}`] = meaningful;
         }
       }
@@ -423,13 +440,13 @@ const buildCellFromTd = (
     (fontWeight.toString() === '400' ||
       fontWeight === 'normal' ||
       _.isEmpty(fontWeight)) &&
-    !_.includes(styles['font-style'], 'bold') &&
-    (!styles['font-weight'] || styles['font-weight'] === '400')
+      !_.includes(styles['font-style'], 'bold') &&
+      (!styles['font-weight'] || styles['font-weight'] === '400')
       ? 0
       : 1;
   cell.it =
     (td.style.fontStyle === 'normal' || _.isEmpty(td.style.fontStyle)) &&
-    !_.includes(styles['font-style'], 'italic')
+      !_.includes(styles['font-style'], 'italic')
       ? 0
       : 1;
 
@@ -540,17 +557,24 @@ export function handlePastedTable(
   const containerDiv = document.createElement('div');
   containerDiv.innerHTML = html;
 
-  const tableColGropup = containerDiv.querySelectorAll('colgroup');
+  // Column widths live in different places depending on the source:
+  //  - dsheet copy:   one <colgroup width="72px"> per column (width on the colgroup)
+  //  - external Sheets: a single <colgroup> containing <col width="100"> per column
+  // Prefer the <col> elements (external); fall back to <colgroup> width attrs (dsheet).
+  const colEls = containerDiv.querySelectorAll('col');
+  const colGroupEls = containerDiv.querySelectorAll('colgroup');
+  const widthSources: Element[] =
+    colEls.length > 0 ? Array.from(colEls) : Array.from(colGroupEls);
 
-  tableColGropup.forEach((colGroup, index) => {
-    const colWidth = colGroup?.getAttribute('width');
+  widthSources.forEach((el, index) => {
+    const colWidth = el?.getAttribute('width');
     const intColWidth = parseInt(colWidth || '0', 10);
     if (intColWidth <= 0) return;
     const anchorCol = ctx.luckysheet_select_save![0].column[0];
     const absoluteCol = anchorCol + index;
     const defaultColW =
-      ctx.luckysheetfile[getSheetIndex(ctx, ctx.currentSheetId)!]?.defaultColWidth ??
-      ctx.defaultcollen;
+      ctx.luckysheetfile[getSheetIndex(ctx, ctx.currentSheetId)!]
+        ?.defaultColWidth ?? ctx.defaultcollen;
     if (intColWidth !== defaultColW) {
       setColumnWidth(ctx, { [absoluteCol]: intColWidth });
     }
@@ -601,9 +625,20 @@ export function handlePastedTable(
     const anchorRow = ctx.luckysheet_select_save![0].row[0];
     const targetRowIndex = anchorRow + localRowIndex;
 
+    // Row height lives in different places depending on the source:
+    //  - <tr height> attribute      (some external apps)
+    //  - <tr style="height:20px">   (external Sheets — inline style on the row)
+    //  - inline style on first <td> (dsheet copy)
+    // Prefer them in that order.
     const explicitRowHeightAttr = tr.getAttribute('height');
-    if (!_.isNil(explicitRowHeightAttr)) {
-      const explicitRowHeight = parseInt(explicitRowHeightAttr, 10);
+    const trInlineHeight = (tr as HTMLElement).style?.height || '';
+    const firstCellInlineHeight =
+      (tr.querySelector('td, th') as HTMLElement | null)?.style?.height || '';
+    const rowHeightRaw = !_.isNil(explicitRowHeightAttr)
+      ? explicitRowHeightAttr
+      : trInlineHeight || firstCellInlineHeight;
+    const parsedRowHeight = parseInt(rowHeightRaw, 10);
+    if (!Number.isNaN(parsedRowHeight) && parsedRowHeight > 0) {
       const defaultRowH = sheetFile.defaultRowHeight ?? ctx.defaultrowlen;
       const hasCustomRowHeight = _.has(
         sheetFile.config?.rowlen,
@@ -614,12 +649,12 @@ export function handlePastedTable(
         : defaultRowH;
 
       if (
-        explicitRowHeight !== defaultRowH &&
-        currentRowHeight !== explicitRowHeight
+        parsedRowHeight !== defaultRowH &&
+        currentRowHeight !== parsedRowHeight
       ) {
-        rowHeightsConfig[targetRowIndex] = explicitRowHeight;
+        rowHeightsConfig[targetRowIndex] = parsedRowHeight;
         setRowHeight(ctx, {
-          [String(targetRowIndex)]: explicitRowHeight,
+          [String(targetRowIndex)]: parsedRowHeight,
         });
       }
     }

--- a/src/sheet-engine/core/paste/clipboard-entry.ts
+++ b/src/sheet-engine/core/paste/clipboard-entry.ts
@@ -25,13 +25,6 @@ import {
   shouldHandleNonTableHtml,
 } from './paste-internals';
 
-function isExternalHtmlPaste(html: string): boolean {
-  return (
-    html.indexOf('fortune-copy-action-table') === -1 &&
-    html.indexOf('fortune-copy-action-span') === -1
-  );
-}
-
 function hasPendingCellCopy(ctx: Context): boolean {
   return (
     ctx.luckysheet_copy_save?.copyRange != null &&
@@ -130,12 +123,13 @@ export function handlePaste(ctx: Context, e: ClipboardEvent) {
     }
     const { internalFortunePaste } = fortunePaste;
 
-    if (
+    const useInternal =
       (txtdata.indexOf('fortune-copy-action-table') > -1 ||
         txtdata.indexOf('fortune-copy-action-span') > -1) &&
       hasPendingCellCopy(ctx) &&
-      internalFortunePaste
-    ) {
+      internalFortunePaste;
+
+    if (useInternal) {
       tryPasteFromInternalCellClipboard(ctx, pasteValuesOnly);
     } else {
       const shouldHandleAsHtml =
@@ -147,9 +141,14 @@ export function handlePaste(ctx: Context, e: ClipboardEvent) {
           ? txtdata
           : convertAnyHtmlToTable(txtdata);
         handlePastedTable(ctx, converted, pasteHandler);
-        if (hasNativeTable && !isExternalHtmlPaste(txtdata)) {
-          resizePastedCellsToContent(ctx);
-        }
+        // Previously the content auto-fit ran here for dsheet→dsheet (fortune) pastes.
+        // That OVERRODE the source geometry: measuring the whole pasted range (e.g. an
+        // entire sheet) inflated each column to its widest cell anywhere in the column
+        // and then collapsed tall wrapped rows measured at the inflated width. Now that
+        // handlePastedTable restores geometry exactly — column widths from <colgroup>,
+        // row heights from the first cell's inline style — the auto-fit is unnecessary
+        // and harmful for fortune pastes, so it is not run here. (External HTML pastes
+        // already did not resize here; that behaviour is unchanged.)
       } else if (
         clipboardData.files.length === 1 &&
         clipboardData.files[0].type.indexOf('image') > -1

--- a/src/sheet-engine/core/utils/cell-persist-utils.test.ts
+++ b/src/sheet-engine/core/utils/cell-persist-utils.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CSS_SAFE_CLIPBOARD_ATTRS,
+  isClipboardMetadataRedundant,
+} from './cell-persist-utils';
+import type { Cell } from '../types';
+
+describe('isClipboardMetadataRedundant', () => {
+  it('keeps blob for cells with content', () => {
+    expect(isClipboardMetadataRedundant({ v: 'x', m: 'x' } as Cell)).toBe(false);
+    expect(isClipboardMetadataRedundant({ f: '=A1' } as Cell)).toBe(false);
+    expect(isClipboardMetadataRedundant('plain')).toBe(false);
+    expect(isClipboardMetadataRedundant(42)).toBe(false);
+  });
+
+  it('drops blob for format-only empty cells reconstructible from CSS', () => {
+    expect(isClipboardMetadataRedundant({ bg: '#f00' } as Cell)).toBe(true);
+    expect(isClipboardMetadataRedundant({ bl: 1, fc: '#111' } as Cell)).toBe(
+      true,
+    );
+    expect(
+      isClipboardMetadataRedundant({ bg: '#eee', ht: 0, fs: 12 } as Cell),
+    ).toBe(true);
+  });
+
+  it('keeps blob for non-CSS format channels (ct number format, tr rotation)', () => {
+    expect(
+      isClipboardMetadataRedundant({ ct: { fa: '0.00', t: 'n' } } as Cell),
+    ).toBe(false);
+    expect(isClipboardMetadataRedundant({ tr: 45 } as unknown as Cell)).toBe(
+      false,
+    );
+    // mixed: one non-CSS attr present → keep
+    expect(
+      isClipboardMetadataRedundant({
+        bg: '#f00',
+        ct: { fa: '0.00', t: 'n' },
+      } as Cell),
+    ).toBe(false);
+  });
+
+  it('drops blob for truly empty cells', () => {
+    expect(isClipboardMetadataRedundant(null)).toBe(true);
+    expect(isClipboardMetadataRedundant(undefined)).toBe(true);
+    expect(isClipboardMetadataRedundant({} as Cell)).toBe(true);
+  });
+
+  it('safe-attr set excludes ct and tr', () => {
+    const set = new Set<string>(CSS_SAFE_CLIPBOARD_ATTRS);
+    expect(set.has('ct')).toBe(false);
+    expect(set.has('tr')).toBe(false);
+    expect(set.has('bg')).toBe(true);
+  });
+});

--- a/src/sheet-engine/core/utils/cell-persist-utils.ts
+++ b/src/sheet-engine/core/utils/cell-persist-utils.ts
@@ -88,6 +88,46 @@ export function shouldPersistCelldataCell(
   return hasCellMeaningfulContent(cell);
 }
 
+// Cell format attrs that getStyleByCell (modules/cell.ts) emits as CSS and
+// buildCellFromTd (paste-table-helpers.ts) parses back. Kept in sync with those
+// two functions: emitting a new attr as CSS on the copy side AND parsing it on
+// the paste side means adding the attr here. `ct` (number format) and `tr`
+// (rotation) are intentionally excluded — the emitted <td> CSS has no channel
+// for them, so a cell carrying them must keep its `data-fortune-cell` blob.
+export const CSS_SAFE_CLIPBOARD_ATTRS = [
+  "bg",
+  "ht",
+  "tb",
+  "ff",
+  "vt",
+  "fs",
+  "fc",
+  "bl",
+  "it",
+  "un",
+  "cl",
+] as const;
+
+const CSS_SAFE_CLIPBOARD_ATTR_SET = new Set<string>(CSS_SAFE_CLIPBOARD_ATTRS);
+
+/**
+ * True when a cell's `data-fortune-cell` clipboard blob is redundant: the cell
+ * has no persistable content and its only format attrs are ones the emitted
+ * `<td>` CSS already carries, so cross-document paste reconstructs it losslessly
+ * from CSS alone. Cells with content, or with a non-CSS format channel
+ * (`ct` / `tr`), return false and keep their blob.
+ */
+export function isClipboardMetadataRedundant(
+  cell: Cell | string | number | boolean | null | undefined,
+): boolean {
+  if (shouldPersistCelldataCell(cell)) return false;
+  const attrs = extractCellFormatAttrs(cell);
+  if (attrs == null) return true;
+  return Object.keys(attrs).every((key) =>
+    CSS_SAFE_CLIPBOARD_ATTR_SET.has(key),
+  );
+}
+
 export function celldataEntryEqual(existing: unknown, next: unknown): boolean {
   if (existing === next) return true;
   if (existing == null || next == null) return false;

--- a/src/sheet-engine/react/components/Workbook/index.tsx
+++ b/src/sheet-engine/react/components/Workbook/index.tsx
@@ -1,3 +1,4 @@
+import { toast } from '@fileverse/ui';
 import {
   defaultContext,
   defaultSettings,
@@ -1653,23 +1654,56 @@ const Workbook = React.forwardRef<WorkbookInstance, Settings & AdditionalProps>(
                 id: context.currentSheetId,
               }
               : null;
-          setContextWithProduce(
-            (draftCtx) => {
-              try {
-                if (insertRowColOp) {
-                  insertRowCol(draftCtx, insertRowColOp);
-                  draftCtx.luckysheet_select_save = range;
+          const runPaste = (pasteEvent: ClipboardEvent) => {
+            setContextWithProduce(
+              (draftCtx) => {
+                try {
+                  if (insertRowColOp) {
+                    insertRowCol(draftCtx, insertRowColOp);
+                    draftCtx.luckysheet_select_save = range;
+                  }
+                  if (startPaste) {
+                    startPaste = false;
+                    handlePaste(draftCtx, pasteEvent);
+                  }
+                } catch (err: any) {
+                  console.error(err);
                 }
-                if (startPaste) {
-                  startPaste = false;
-                  handlePaste(draftCtx, e);
-                }
-              } catch (err: any) {
-                console.error(err);
-              }
-            },
-            insertRowColOp ? { insertRowColOp } : {},
-          );
+              },
+              insertRowColOp ? { insertRowColOp } : {},
+            );
+          };
+
+          // Large pastes block the main thread while cells are parsed/laid out.
+          // Show a toast, then defer the heavy work a frame so it can paint before
+          // the UI freezes. handlePaste only reads clipboardData.getData/files and
+          // preventDefault, so a captured-string synthetic event drives it after the
+          // native event is gone.
+          const LARGE_PASTE_BYTES = 500_000;
+          if (txtdata.length > LARGE_PASTE_BYTES) {
+            e.preventDefault();
+            const htmlData = clipboardData!.getData('text/html');
+            const plainData = clipboardData!.getData('text/plain');
+            const deferredEvent = {
+              clipboardData: {
+                getData: (type: string) =>
+                  type === 'text/html' ? htmlData : plainData,
+                files: { length: 0 },
+              },
+              preventDefault: () => {},
+            } as unknown as ClipboardEvent;
+            toast({
+              title: 'Large content paste in progress',
+              variant: 'warning',
+              showCloseButton: true,
+              duration: 30 * 1000,
+            });
+            requestAnimationFrame(() =>
+              requestAnimationFrame(() => runPaste(deferredEvent)),
+            );
+          } else {
+            runPaste(e);
+          }
         }
         setContextWithProduce((ctx: any) => {
           if (ctx.luckysheet_selection_range) {


### PR DESCRIPTION
## fix: dsheet to dsheet & external to dsheet copy paste 

Root cause
- Row height was read only from a <tr> height attribute that our copy never emits (it's inline on the first cell); external sheets put it on the row's inline style. → heights lost.
- Column width was read only from the column-group element; external sheets put width on the individual column elements. → widths lost.
- On whole-selection paste, a post-paste content auto-fit re-measured the entire grid and overrode the clipboard geometry (a long cell anywhere inflated its column to the cap, collapsing wrapped rows).
- The inline-string run builder copied every cell style onto each text run, including the cell border; underline is encoded internally as a bottom border, so bordered cells (external) underlined all text.
- The border parser rejected any width < 1px, dropping our 0.5pt thin borders (external sends 1px), so the app gridline showed through inter-cell gaps as white lines.

Fix
- Restore row height from the row's inline style / first-cell inline style; restore column width from individual column elements, falling back to the column group.
- Skip the content auto-fit for internal (dsheet) pastes — the clipboard already carries exact width + height.
- Don't propagate cell-level border props onto text runs.
- Reject only zero-width borders; keep sub-1px thin borders.


## perf(copy): clamp copied range to used bounds 

Root cause: Copying a mostly-empty selection (especially select-all of a large sheet) serialized a styled <td> for every allocated cell - tens of MB of clipboard HTML, ~99% blank.

Fix: Before building the HTML, trim the serialized range to the bounding box of cells that actually carry content (value, border, or conditional format); a fully-empty selection collapses to one cell. Dropped cells hold no data or style, so the copy stays lossless and matches Google's used-range behavior.


## perf(copy): skip clipboard metadata for CSS-reconstructible empty cells

Root cause: Every cell carried a data-fortune-cell JSON blob (the internal cell model). For empty cells whose only state is format that's already emitted as inline CSS and parsed back on paste, that blob is pure duplication — extra bytes per cell.

Fix: Skip the JSON blob for empty cells whose formatting is fully reconstructible from the emitted CSS (bg, color, bold/italic, borders, alignment). Keep it when the cell has non-CSS channels (number format, rotation, value, merge). Paste rebuilds those cells from the inline styles, so no fidelity is lost.

## fix: preserve font and cell geometry across dsheet paste round-trips

Root cause: Two independent halves disagreed on the default dimension -

- On paste, geometry restore only writes an explicit width/height entry when the pasted value differs from the target sheet's default. When a pasted column's width equals the sheet default, it correctly writes nothing — the grid already renders at that default, so the paste itself looks correct.
On copy, when a column/row has no explicit entry, serialization emitted a hardcoded fallback dimension instead of the sheet's actual default.
- When the sheet's real default didn't match that hardcoded constant, copy baked the wrong dimension into the clipboard. The corruption therefore appeared one step later — not on the paste, but on the next paste of the copied result, which resized everything to the hardcoded value. Row height carried the identical latent defect; it stayed hidden only because the affected rows all had non-default (custom) heights.

Fix: Copy serialization now emits the sheet's actual default width/height (falling back to the engine-level default) instead of a hardcoded constant, for both columns and rows. Default-sized cells now round-trip losslessly, and the clipboard geometry always matches what the grid renders.