### PR TITLE
fix: UK date parity with GSheets for parse and display

### DIFF
--- a/src/sheet-engine/core/api/cell.ts
+++ b/src/sheet-engine/core/api/cell.ts
@@ -43,7 +43,15 @@ export function getCellValue(
       ret = functionHTMLGenerate(ret);
     } else if (type === 'f') {
       ret = cellData.v;
-    } else if (cellData && cellData.ct && cellData.ct.fa === 'yyyy-MM-dd') {
+    } else if (
+      cellData &&
+      cellData.ct &&
+      (cellData.ct.fa === 'yyyy-MM-dd' ||
+        cellData.ct.fa === 'd/M/yyyy' ||
+        cellData.ct.fa === 'dd/MM/yyyy' ||
+        cellData.ct.fa === 'M/d/yyyy' ||
+        cellData.ct.fa === 'MM/dd/yyyy')
+    ) {
       ret = cellData.m;
     } else if (cellData.ct?.t === 'inlineStr') {
       ret = cellData.ct.s.reduce(

--- a/src/sheet-engine/core/index.ts
+++ b/src/sheet-engine/core/index.ts
@@ -87,6 +87,7 @@ export {
   getRangeRectsByCharacterOffset,
   // date base locale
   getDateBaseLocale,
+  getCanonicalDateDisplayFormat,
   getCanonicalDateEditFormat,
   getDateEditFormatForCell,
   isUsDateBaseLocale,

--- a/src/sheet-engine/core/locale/en.ts
+++ b/src/sheet-engine/core/locale/en.ts
@@ -11219,18 +11219,18 @@ export default {
       example: `${currency}1,200.09`,
     },
     { text: '', value: 'split', example: '' },
-    { text: 'Date', value: 'yyyy-MM-dd', example: '2017-11-29' },
+    { text: 'Date', value: 'd/M/yyyy', example: '29/11/2017' },
     { text: 'Time', value: 'hh:mm AM/PM', example: '3:00 PM' },
     { text: 'Time 24H', value: 'hh:mm', example: '15:00' },
     {
       text: 'Date time',
-      value: 'yyyy-MM-dd hh:mm AM/PM',
-      example: '2017-11-29 3:00 PM',
+      value: 'd/M/yyyy hh:mm AM/PM',
+      example: '29/11/2017 3:00 PM',
     },
     {
       text: 'Date time 24 H',
-      value: 'yyyy-MM-dd hh:mm',
-      example: '2017-11-29 15:00',
+      value: 'd/M/yyyy hh:mm',
+      example: '29/11/2017 15:00',
     },
     { text: '', value: 'split', example: '' },
     {
@@ -11242,6 +11242,14 @@ export default {
   ],
   dateFmtList: [
     {
+      name: '5/8/1930',
+      value: 'd/M/yyyy',
+    },
+    {
+      name: '05/08/1930',
+      value: 'dd/MM/yyyy',
+    },
+    {
       name: '1930-08-05',
       value: 'yyyy-MM-dd',
     },
@@ -11250,12 +11258,8 @@ export default {
       value: 'yyyy/MM/dd',
     },
     {
-      name: '08-05',
-      value: 'MM-dd',
-    },
-    {
-      name: '8-5',
-      value: 'M-d',
+      name: '5-8',
+      value: 'd-M',
     },
     {
       name: '13:30:30',

--- a/src/sheet-engine/core/locale/es.ts
+++ b/src/sheet-engine/core/locale/es.ts
@@ -11217,26 +11217,26 @@ export default {
     { text: 'Moneda', value: `${currency}0.00`, example: `${currency}1200.09` },
 
     { text: '', value: 'split', example: '' },
-    { text: 'Fecha', value: 'yyyy-MM-dd', example: '2017-11-29' },
+    { text: 'Fecha', value: 'd/M/yyyy', example: '29/11/2017' },
     { text: 'Hora', value: 'hh:mm AM/PM', example: '3:00 PM' },
     { text: 'Hora 24H', value: 'hh:mm', example: '15:00' },
     {
       text: 'Fecha Hora',
-      value: 'yyyy-MM-dd hh:mm AM/PM',
-      example: '2017-11-29 3:00 PM',
+      value: 'd/M/yyyy hh:mm AM/PM',
+      example: '29/11/2017 3:00 PM',
     },
     {
       text: 'Fecha Hora 24 H',
-      value: 'yyyy-MM-dd hh:mm',
-      example: '2017-11-29 15:00',
+      value: 'd/M/yyyy hh:mm',
+      example: '29/11/2017 15:00',
     },
     { text: '', value: 'split', example: '' },
     { text: 'Formatos personalizados', value: 'fmtOtherSelf', example: 'más' },
   ],
   dateFmtList: [
     {
-      name: '1930-08-05',
-      value: 'yyyy-MM-dd',
+      name: '5/8/1930',
+      value: 'd/M/yyyy',
     },
     {
       name: '1930/8/5',

--- a/src/sheet-engine/core/locale/hi.ts
+++ b/src/sheet-engine/core/locale/hi.ts
@@ -11250,18 +11250,18 @@ export default {
     { text: 'मुद्रा', value: `${currency}0.00`, example: `${currency}1200.09` },
 
     { text: '', value: 'split', example: '' },
-    { text: 'दिनांक', value: 'yyyy-MM-dd', example: '2017-11-29' },
+    { text: 'दिनांक', value: 'd/M/yyyy', example: '29/11/2017' },
     { text: 'समय', value: 'hh:mm AM/PM', example: '3:00 PM' },
     { text: '24 घंटे का समय', value: 'hh:mm', example: '15:00' },
     {
       text: 'दिनांक समय',
-      value: 'yyyy-MM-dd hh:mm AM/PM',
-      example: '2017-11-29 3:00 PM',
+      value: 'd/M/yyyy hh:mm AM/PM',
+      example: '29/11/2017 3:00 PM',
     },
     {
       text: 'दिनांक समय 24 घंटे',
-      value: 'yyyy-MM-dd hh:mm',
-      example: '2017-11-29 15:00',
+      value: 'd/M/yyyy hh:mm',
+      example: '29/11/2017 15:00',
     },
     { text: '', value: 'split', example: '' },
     {
@@ -11273,8 +11273,8 @@ export default {
   ],
   dateFmtList: [
     {
-      name: '1930-08-05',
-      value: 'yyyy-MM-dd',
+      name: '5/8/1930',
+      value: 'd/M/yyyy',
     },
     {
       name: '1930/8/5',

--- a/src/sheet-engine/core/locale/zh.ts
+++ b/src/sheet-engine/core/locale/zh.ts
@@ -11229,18 +11229,18 @@ export default {
     // { "text": "货币整数", "value": "¥####", "example": "¥1200" },
     { text: '万元2位小数', value: 'w0.00', example: '2万2500.55' },
     { text: '', value: 'split', example: '' },
-    { text: '日期', value: 'yyyy-MM-dd', example: '2017-11-29' },
+    { text: '日期', value: 'd/M/yyyy', example: '29/11/2017' },
     { text: '时间', value: 'hh:mm AM/PM', example: '3:00 PM' },
     { text: '时间24H', value: 'hh:mm', example: '15:00' },
     {
       text: '日期时间',
-      value: 'yyyy-MM-dd hh:mm AM/PM',
-      example: '2017-11-29 3:00 PM',
+      value: 'd/M/yyyy hh:mm AM/PM',
+      example: '29/11/2017 3:00 PM',
     },
     {
       text: '日期时间24H',
-      value: 'yyyy-MM-dd hh:mm',
-      example: '2017-11-29 15:00',
+      value: 'd/M/yyyy hh:mm',
+      example: '29/11/2017 15:00',
     },
     { text: '', value: 'split', example: '' },
     {
@@ -11252,8 +11252,8 @@ export default {
   ],
   dateFmtList: [
     {
-      name: '1930-08-05',
-      value: 'yyyy-MM-dd',
+      name: '5/8/1930',
+      value: 'd/M/yyyy',
     },
     {
       name: '1930/8/5',

--- a/src/sheet-engine/core/locale/zh_tw.ts
+++ b/src/sheet-engine/core/locale/zh_tw.ts
@@ -11196,26 +11196,26 @@ export default {
     // { "text": "貨幣整數", "value": "¥####", "example": "¥1200" },
     { text: '萬元2位小數', value: 'w0.00', example: '2万2500.55' },
     { text: '', value: 'split', example: '' },
-    { text: '日期', value: 'yyyy-MM-dd', example: '2017-11-29' },
+    { text: '日期', value: 'd/M/yyyy', example: '29/11/2017' },
     { text: '時間', value: 'hh:mm AM/PM', example: '3:00 PM' },
     { text: '時間24H', value: 'hh:mm', example: '15:00' },
     {
       text: '日期時間',
-      value: 'yyyy-MM-dd hh:mm AM/PM',
-      example: '2017-11-29 3:00 PM',
+      value: 'd/M/yyyy hh:mm AM/PM',
+      example: '29/11/2017 3:00 PM',
     },
     {
       text: '日期時間24H',
-      value: 'yyyy-MM-dd hh:mm',
-      example: '2017-11-29 15:00',
+      value: 'd/M/yyyy hh:mm',
+      example: '29/11/2017 15:00',
     },
     { text: '', value: 'split', example: '' },
     { text: '自定義格式', value: 'fmtOtherSelf', example: 'more' },
   ],
   dateFmtList: [
     {
-      name: '1930-08-05',
-      value: 'yyyy-MM-dd',
+      name: '5/8/1930',
+      value: 'd/M/yyyy',
     },
     {
       name: '1930/8/5',

--- a/src/sheet-engine/core/modules/date-base-locale.ts
+++ b/src/sheet-engine/core/modules/date-base-locale.ts
@@ -18,11 +18,19 @@ export function isUsDateBaseLocale(): boolean {
   return activeDateBaseLocale === 'us';
 }
 
+/** Standard Date toolbar / formula display format (no leading zeros). */
+export function getCanonicalDateDisplayFormat(hasTime = false): string {
+  if (isUsDateBaseLocale()) {
+    return hasTime ? 'M/d/yyyy hh:mm AM/PM' : 'M/d/yyyy';
+  }
+  return hasTime ? 'd/M/yyyy hh:mm AM/PM' : 'd/M/yyyy';
+}
+
 export function getCanonicalDateEditFormat(hasTime: boolean): string {
   if (isUsDateBaseLocale()) {
-    return hasTime ? 'MM/dd/yyyy HH:mm:ss' : 'MM/dd/yyyy';
+    return hasTime ? 'M/d/yyyy HH:mm:ss' : 'M/d/yyyy';
   }
-  return hasTime ? 'dd/MM/yyyy HH:mm:ss' : 'dd/MM/yyyy';
+  return hasTime ? 'd/M/yyyy HH:mm:ss' : 'd/M/yyyy';
 }
 
 function normalizeDateFormatTokenOrder(format: string): Array<'d' | 'm' | 'y'> {

--- a/src/sheet-engine/core/modules/format.ts
+++ b/src/sheet-engine/core/modules/format.ts
@@ -1,7 +1,7 @@
 import numeral from 'numeral';
 import _ from 'lodash';
 import { isRealNum, valueIsError, detectDateFormat } from './validation';
-import { getDateBaseLocale } from './date-base-locale';
+import { getCanonicalDateDisplayFormat } from './date-base-locale';
 // @ts-ignore
 import SSF from './ssf';
 import { Cell, CellMatrix } from '../types';
@@ -361,7 +361,13 @@ export function genarate(value: string | number | boolean) {
       );
       v = datenum_local(dateObj);
       ct.t = 'd';
-
+      // Preserve the typed pattern on auto-input (GSheets-like).
+      // Toolbar Format → Date applies getCanonicalDateDisplayFormat separately.
+      const hasTime =
+        df.hours !== 0 ||
+        df.minutes !== 0 ||
+        df.seconds !== 0 ||
+        /H|h|AM\/PM|T/i.test(df.formatType);
       const map: Record<string, string> = {
         'yyyy-MM-dd': 'yyyy-MM-dd',
         'yyyy-MM-dd HH:mm': 'yyyy-MM-dd HH:mm',
@@ -403,6 +409,8 @@ export function genarate(value: string | number | boolean) {
         'MM-dd-yy': 'mm-dd-yy',
         'M d yyyy': 'm d yyyy',
         'MM dd yyyy': 'mm dd yyyy',
+        'd M yyyy': 'd m yyyy',
+        'dd MM yyyy': 'dd mm yyyy',
         'MM/yyyy': 'mm/yyyy',
         'M/yyyy': 'm/yyyy',
         'MM-yyyy': 'mm-yyyy',
@@ -433,10 +441,8 @@ export function genarate(value: string | number | boolean) {
         'dy dd/MM/yyyy': 'ddd dd/mm/yyyy',
         'dy MM/dd/yyyy': 'ddd mm/dd/yyyy',
       };
-
       ct.fa =
-        map[df.formatType] ||
-        (getDateBaseLocale() === 'us' ? 'MM/dd/yyyy' : 'dd/MM/yyyy');
+        map[df.formatType] || getCanonicalDateDisplayFormat(hasTime);
       m = SSF.format(ct.fa, v);
     } else {
       m = String(value);

--- a/src/sheet-engine/core/modules/index.ts
+++ b/src/sheet-engine/core/modules/index.ts
@@ -31,6 +31,7 @@ export { moveToEnd, getRangeRectsByCharacterOffset } from './cursor';
 // date base locale
 export {
   getDateBaseLocale,
+  getCanonicalDateDisplayFormat,
   getCanonicalDateEditFormat,
   getDateEditFormatForCell,
   isUsDateBaseLocale,

--- a/src/sheet-engine/core/modules/validation.date.test.ts
+++ b/src/sheet-engine/core/modules/validation.date.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { setDateBaseLocale } from './date-base-locale';
+import { genarate } from './format';
+import { detectDateFormat } from './validation';
+
+describe('detectDateFormat UK locale (GSheets parity)', () => {
+  afterEach(() => {
+    setDateBaseLocale('uk');
+  });
+
+  it('parses day-first slash dates', () => {
+    const d = detectDateFormat('25/02/2026');
+    expect(d).toMatchObject({ year: 2026, month: 2, day: 25 });
+  });
+
+  it('rejects unambiguous US slash dates as text', () => {
+    expect(detectDateFormat('02/25/2026')).toBeNull();
+    expect(detectDateFormat('2/25/2026')).toBeNull();
+  });
+
+  it('interprets ambiguous slash dates as day/month', () => {
+    const d = detectDateFormat('03/04/2026');
+    expect(d).toMatchObject({ year: 2026, month: 4, day: 3 });
+  });
+
+  it('rejects unambiguous US space-separated dates', () => {
+    expect(detectDateFormat('2 25 2026')).toBeNull();
+  });
+
+  it('parses UK space-separated dates', () => {
+    const d = detectDateFormat('25 2 2026');
+    expect(d).toMatchObject({ year: 2026, month: 2, day: 25 });
+  });
+
+  it('parses ISO and named UK-friendly strings', () => {
+    expect(detectDateFormat('2026-02-25')).toMatchObject({
+      year: 2026,
+      month: 2,
+      day: 25,
+    });
+    expect(detectDateFormat('25 February 2026')).toMatchObject({
+      year: 2026,
+      month: 2,
+      day: 25,
+    });
+    expect(detectDateFormat('February 25, 2026')).toMatchObject({
+      year: 2026,
+      month: 2,
+      day: 25,
+    });
+  });
+
+  it('uses Excel/GSheets two-digit year window (00-29 → 2000s, 30-99 → 1900s)', () => {
+    expect(detectDateFormat('12/12/13')).toMatchObject({
+      year: 2013,
+      month: 12,
+      day: 12,
+    });
+    expect(detectDateFormat('12/12/31')).toMatchObject({
+      year: 1931,
+      month: 12,
+      day: 12,
+    });
+    expect(detectDateFormat('12/12/29')).toMatchObject({
+      year: 2029,
+      month: 12,
+      day: 12,
+    });
+    expect(detectDateFormat('12/12/30')).toMatchObject({
+      year: 1930,
+      month: 12,
+      day: 12,
+    });
+  });
+});
+
+describe('detectDateFormat US locale', () => {
+  afterEach(() => {
+    setDateBaseLocale('uk');
+  });
+
+  it('parses month-first slash dates', () => {
+    setDateBaseLocale('us');
+    const d = detectDateFormat('02/25/2026');
+    expect(d).toMatchObject({ year: 2026, month: 2, day: 25 });
+    expect(detectDateFormat('25/02/2026')).toBeNull();
+  });
+});
+
+describe('genarate auto-input date display (GSheets UK parity)', () => {
+  afterEach(() => {
+    setDateBaseLocale('uk');
+  });
+
+  it('preserves typed yy display on auto-input (does not expand to yyyy)', () => {
+    const result = genarate('12/12/98');
+    expect(result).not.toBeNull();
+    const [m, ct] = result!;
+    expect(ct.t).toBe('d');
+    expect(ct.fa).toBe('dd/MM/yy');
+    expect(String(m)).toBe('12/12/98');
+  });
+
+  it('keeps unambiguous US numeric input as non-date text', () => {
+    const result = genarate('02/25/2026');
+    expect(result).not.toBeNull();
+    const [, ct] = result!;
+    expect(ct.t).not.toBe('d');
+  });
+});

--- a/src/sheet-engine/core/modules/validation.ts
+++ b/src/sheet-engine/core/modules/validation.ts
@@ -137,8 +137,14 @@ const WEEKDAY_NAMES_RE =
   'monday|tuesday|wednesday|thursday|friday|saturday|sunday';
 const WEEKDAY_ABBR_RE = 'mon|tue|wed|thu|fri|sat|sun';
 
+/**
+ * Excel / Google Sheets two-digit year window:
+ * 00–29 → 2000–2029, 30–99 → 1930–1999.
+ * e.g. 12/12/13 → 2013, 12/12/31 → 1931.
+ */
 function parseTwoDigitYear(twoDigitYear: string): number {
-  return 2000 + Number(twoDigitYear);
+  const yy = Number(twoDigitYear);
+  return yy <= 29 ? 2000 + yy : 1900 + yy;
 }
 
 function isValidDateParts(year: number, month: number, day: number): boolean {
@@ -338,32 +344,53 @@ export function detectDateFormat(str: string): DateFormatInfo | null {
     }
   }
 
-  // D-M-YYYY / DD-MM-YYYY (day-first)
+  // Dash-separated with 4-digit year (base-order aware). UK: D-M-YYYY, US: M-D-YYYY.
   m = /^(\d{1,2})-(\d{1,2})-(\d{4})$/.exec(s);
   if (m) {
     const p1 = +m[1];
     const p2 = +m[2];
     const y = +m[3];
-    if (p1 <= 31 && p2 <= 12 && isValidDateParts(y, p2, p1)) {
+    const mo = prefersUsDateOrder ? p1 : p2;
+    const d = prefersUsDateOrder ? p2 : p1;
+    if (mo <= 12 && d <= 31 && isValidDateParts(y, mo, d)) {
       return {
         year: y,
-        month: p2,
-        day: p1,
+        month: mo,
+        day: d,
         hours: 0,
         minutes: 0,
         seconds: 0,
-        formatType: m[1].length === 1 ? 'd-M-yyyy' : 'dd-MM-yyyy',
+        formatType: prefersUsDateOrder
+          ? m[1].length === 1
+            ? 'M-d-yyyy'
+            : 'MM-dd-yyyy'
+          : m[1].length === 1
+            ? 'd-M-yyyy'
+            : 'dd-MM-yyyy',
       };
     }
   }
 
-  // dd.MM.yyyy: 25.02.2026 (only when first part > 12 to avoid ambiguity)
+  // Dot-separated with 4-digit year (base-order aware). Unambiguous only when
+  // the day-side part is > 12 so month/day cannot swap.
   m = /^(\d{1,2})\.(\d{1,2})\.(\d{4})$/.exec(s);
   if (m) {
     const p1 = +m[1];
     const p2 = +m[2];
     const y = +m[3];
-    if (p1 > 12 && isValidDateParts(y, p2, p1)) {
+    if (prefersUsDateOrder) {
+      if (p2 > 12 && isValidDateParts(y, p1, p2)) {
+        return {
+          year: y,
+          month: p1,
+          day: p2,
+          hours: 0,
+          minutes: 0,
+          seconds: 0,
+          formatType: 'MM.dd.yyyy',
+        };
+      }
+    } else if (p1 > 12 && isValidDateParts(y, p2, p1)) {
       return {
         year: y,
         month: p2,
@@ -477,13 +504,15 @@ export function detectDateFormat(str: string): DateFormatInfo | null {
     }
   }
 
-  // D-M-YY / DD-MM-YY (day-first)
+  // Dash-separated with 2-digit year (base-order aware)
   m = /^(\d{1,2})-(\d{1,2})-(\d{2})$/.exec(s);
   if (m) {
-    const d = +m[1];
-    const mo = +m[2];
+    const p1 = +m[1];
+    const p2 = +m[2];
     const y = parseTwoDigitYear(m[3]);
-    if (d <= 31 && mo <= 12 && isValidDateParts(y, mo, d)) {
+    const mo = prefersUsDateOrder ? p1 : p2;
+    const d = prefersUsDateOrder ? p2 : p1;
+    if (mo <= 12 && d <= 31 && isValidDateParts(y, mo, d)) {
       return {
         year: y,
         month: mo,
@@ -491,17 +520,26 @@ export function detectDateFormat(str: string): DateFormatInfo | null {
         hours: 0,
         minutes: 0,
         seconds: 0,
-        formatType: m[1].length === 1 ? 'd-M-yy' : 'dd-MM-yy',
+        formatType: prefersUsDateOrder
+          ? m[1].length === 1
+            ? 'M-d-yy'
+            : 'MM-dd-yy'
+          : m[1].length === 1
+            ? 'd-M-yy'
+            : 'dd-MM-yy',
       };
     }
   }
 
-  // M D YYYY / MM DD YYYY
+  // Space-separated numeric (base-order aware). UK: D M YYYY, US: M D YYYY.
+  // Unambiguous wrong-order values (e.g. UK input "2 25 2026") stay text.
   m = /^(\d{1,2})\s+(\d{1,2})\s+(\d{4})$/.exec(s);
   if (m) {
-    const mo = +m[1];
-    const d = +m[2];
+    const p1 = +m[1];
+    const p2 = +m[2];
     const y = +m[3];
+    const mo = prefersUsDateOrder ? p1 : p2;
+    const d = prefersUsDateOrder ? p2 : p1;
     if (isValidDateParts(y, mo, d)) {
       return {
         year: y,
@@ -510,7 +548,13 @@ export function detectDateFormat(str: string): DateFormatInfo | null {
         hours: 0,
         minutes: 0,
         seconds: 0,
-        formatType: m[1].length === 1 ? 'M d yyyy' : 'MM dd yyyy',
+        formatType: prefersUsDateOrder
+          ? m[1].length === 1
+            ? 'M d yyyy'
+            : 'MM dd yyyy'
+          : m[1].length === 1
+            ? 'd M yyyy'
+            : 'dd MM yyyy',
       };
     }
   }


### PR DESCRIPTION
Use day-first locale parsing, Excel-style two-digit year windows, and preserve typed yy formats on auto-input while standard Date remains d/M/yyyy.